### PR TITLE
Enhance DT monitoring setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: Version of the dynatrace-sli-service
     default: '0.9.0'
     required: false
+  SetupMonaco:
+    description: Set up Monaco capabilities
+    default: 'false'
+    required: false
 runs:
   using: composite
   steps:
@@ -35,7 +39,15 @@ runs:
         BASE_PATH: ${{ github.action_path }}
         DYNATRACE_SERVICE_VERSION: ${{ inputs.DynatraceServiceVersion }}
         DYNATRACE_SLI_SERVICE_VERSION: ${{ inputs.DynatraceSLIServiceVersion }}
+        MONACO_SERVICE_VERSION: ${{ inputs.MonacoServiceVersion }}
       run: ${{ github.action_path }}/deploy_dynatrace.sh
+
+    - shell: bash
+      id: deploy_monaco_service
+      env:
+        MONACO_SERVICE_VERSION: ${{ inputs.MonacoServiceVersion }}
+        BASE_PATH: ${{ github.action_path }}
+      run: ${{ github.action_path }}/setup_monaco.sh
 
 
 

--- a/assets/monaco/auto-tag/keptn_selfmon_namespace.json
+++ b/assets/monaco/auto-tag/keptn_selfmon_namespace.json
@@ -1,0 +1,27 @@
+{
+  "name": "{{ .name }}",
+  "rules": [
+    {
+      "type": "SERVICE",
+      "enabled": true,
+      "valueFormat": "{ProcessGroup:KubernetesNamespace}",
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "PROCESS_GROUP_PREDEFINED_METADATA",
+            "dynamicKey": "KUBERNETES_NAMESPACE",
+            "type": "PROCESS_PREDEFINED_METADATA_KEY"
+          },
+          "comparisonInfo": {
+            "type": "STRING",
+            "operator": "BEGINS_WITH",
+            "value": "{{ .projectName }}",
+            "negate": false,
+            "caseSensitive": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/assets/monaco/auto-tag/keptn_selfmon_service.json
+++ b/assets/monaco/auto-tag/keptn_selfmon_service.json
@@ -1,0 +1,27 @@
+{
+  "name": "{{ .name }}",
+  "rules": [
+    {
+      "type": "SERVICE",
+      "enabled": true,
+      "valueFormat": "{ProcessGroup:KubernetesContainerName}",
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "PROCESS_GROUP_PREDEFINED_METADATA",
+            "dynamicKey": "KUBERNETES_NAMESPACE",
+            "type": "PROCESS_PREDEFINED_METADATA_KEY"
+          },
+          "comparisonInfo": {
+            "type": "STRING",
+            "operator": "BEGINS_WITH",
+            "value": "{{ .projectName }}",
+            "negate": false,
+            "caseSensitive": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/assets/monaco/auto-tag/tagging.yaml
+++ b/assets/monaco/auto-tag/tagging.yaml
@@ -1,0 +1,11 @@
+config:
+  - keptn-selfmon-namespace: "keptn_selfmon_namespace.json"
+  - keptn-selfmon-service: "keptn_selfmon_service.json"
+
+keptn-selfmon-namespace:
+  - name: "Keptn self monitoring namespace"
+  - projectName: {{ .Env.KEPTN_PROJECT }}
+
+keptn-selfmon-service:
+  - name: "Keptn self monitoring service"
+  - projectName: {{ .Env.KEPTN_PROJECT }}

--- a/assets/monaco/calculated-metrics-service/calculated-metrics-service.yaml
+++ b/assets/monaco/calculated-metrics-service/calculated-metrics-service.yaml
@@ -1,0 +1,7 @@
+config:
+  - calculated-metrics-fastrequests: "fast_requests.json"
+
+calculated-metrics-fastrequests:
+  - id: "calc:service.fastkeptnrequests"
+  - name: "Fast Requests"
+  - mZoneId: "/{{ .Env.KEPTN_PROJECT }}/management-zone/keptn.name"

--- a/assets/monaco/calculated-metrics-service/fast_requests.json
+++ b/assets/monaco/calculated-metrics-service/fast_requests.json
@@ -1,0 +1,43 @@
+{
+  "tsmMetricKey": "{{ .id }}",
+  "name": "{{ .name }}",
+  "enabled": true,
+  "metricDefinition": {
+    "metric": "REQUEST_COUNT",
+    "requestAttribute": null
+  },
+  "unit": "COUNT",
+  "unitDisplayName": null,
+  "managementZones": ["{{ .mZoneId }}"],
+  "conditions": [
+    {
+      "attribute": "REQUEST_TYPE",
+      "comparisonInfo": {
+        "type": "STRING",
+        "comparison": "EQUALS",
+        "value": "Dynamic web requests",
+        "values": null,
+        "negate": false,
+        "caseSensitive": false
+      }
+    },
+    {
+      "attribute": "RESPONSE_TIME",
+      "comparisonInfo": {
+        "type": "NUMBER",
+        "comparison": "LOWER_THAN_OR_EQUAL",
+        "value": 300,
+        "values": null,
+        "negate": false
+      }
+    }
+  ],
+  "dimensionDefinition": {
+    "name": "Dimension",
+    "dimension": "All requests",
+    "placeholders": [],
+    "topX": 10,
+    "topXDirection": "DESCENDING",
+    "topXAggregation": "SINGLE_VALUE"
+  }
+}

--- a/assets/monaco/conditional-naming/conditional-naming-service.yaml
+++ b/assets/monaco/conditional-naming/conditional-naming-service.yaml
@@ -1,0 +1,6 @@
+config:
+  - service-naming: "keptn_service.json"
+
+service-naming:
+  - name: "Keptn Service Name"
+  - serviceName: "{{ .Env.KEPTN_PROJECT }}-{{ .Env.KEPTN_STAGE }}"

--- a/assets/monaco/conditional-naming/keptn_service.json
+++ b/assets/monaco/conditional-naming/keptn_service.json
@@ -1,0 +1,35 @@
+{
+  "type": "SERVICE",
+  "nameFormat": "{ProcessGroup:KubernetesContainerName}",
+  "displayName": "{{ .name }}",
+  "enabled": true,
+  "rules": [
+    {
+      "key": {
+        "attribute": "PROCESS_GROUP_PREDEFINED_METADATA",
+        "dynamicKey": "KUBERNETES_NAMESPACE",
+        "type": "PROCESS_PREDEFINED_METADATA_KEY"
+      },
+      "comparisonInfo": {
+        "type": "STRING",
+        "operator": "EQUALS",
+        "value": "{{ .serviceName }}",
+        "negate": false,
+        "caseSensitive": true
+      }
+    },
+    {
+      "key": {
+        "attribute": "SERVICE_DETECTED_NAME",
+        "type": "STATIC"
+      },
+      "comparisonInfo": {
+        "type": "STRING",
+        "operator": "EQUALS",
+        "value": "default web request",
+        "negate": false,
+        "caseSensitive": true
+      }
+    }
+  ]
+}

--- a/assets/monaco/management-zone/zone.json
+++ b/assets/monaco/management-zone/zone.json
@@ -1,0 +1,30 @@
+{
+  "name": "{{ .name }}",
+  "rules": [
+    {
+      "type": "SERVICE",
+      "enabled": true,
+      "propagationTypes": [],
+      "conditions": [
+        {
+          "key": {
+            "attribute": "SERVICE_TAGS",
+            "type": "STATIC"
+          },
+          "comparisonInfo": {
+            "type": "TAG",
+            "operator": "EQUALS",
+            "value": {
+              "context": "CONTEXTLESS",
+              "key": "keptn_selfmon_namespace",
+              "value": "{{ .name }}"
+            },
+            "negate": false
+          }
+        }
+      ]
+    }
+  ],
+  "dimensionalRules": [],
+  "entitySelectorBasedRules": []
+}

--- a/assets/monaco/management-zone/zone.yaml
+++ b/assets/monaco/management-zone/zone.yaml
@@ -1,0 +1,5 @@
+config:
+  - keptn: "zone.json"
+
+keptn:
+  - name: "{{ .Env.KEPTN_PROJECT }}-{{ .Env.KEPTN_STAGE }}"

--- a/assets/monaco/slo/performance.json
+++ b/assets/monaco/slo/performance.json
@@ -1,0 +1,20 @@
+{
+  "enabled": true,
+  "name": "{{ .name }}}}",
+  "description": "",
+  "evaluatedPercentage": -1.0,
+  "errorBudget": -1.0,
+  "status": "SUCCESS",
+  "error": "NONE",
+  "useRateMetric": false,
+  "metricRate": "",
+  "metricNumerator": "calc:service.fastmongodbdatastorerequests",
+  "numeratorValue": -1.0,
+  "metricDenominator": "builtin:service.requestCount.server",
+  "denominatorValue": -1.0,
+  "target": 99.98,
+  "warning": 99.99,
+  "evaluationType": "AGGREGATE",
+  "timeframe": "-1w",
+  "filter": "type(\"SERVICE\"),tag(\"keptn_selfmon_namespace:{{ .project }}-{{ .stage }}\",\"keptn_selfmon_namespace:{{ .service }}\")"
+}

--- a/assets/monaco/slo/performance.json
+++ b/assets/monaco/slo/performance.json
@@ -8,7 +8,7 @@
   "error": "NONE",
   "useRateMetric": false,
   "metricRate": "",
-  "metricNumerator": "calc:service.fastmongodbdatastorerequests",
+  "metricNumerator": "{{ .metricId }}",
   "numeratorValue": -1.0,
   "metricDenominator": "builtin:service.requestCount.server",
   "denominatorValue": -1.0,

--- a/assets/monaco/slo/service_availability.json
+++ b/assets/monaco/slo/service_availability.json
@@ -1,0 +1,13 @@
+{
+  "enabled": true,
+  "name": "{{.name}}",
+  "useRateMetric": true,
+  "metricRate": "builtin:service.successes.server.rate",
+  "metricNumerator": "builtin:service.errors.server.successCount",
+  "metricDenominator": "builtin:service.requestCount.total",
+  "evaluationType": "AGGREGATE",
+  "filter": "type(\"SERVICE\"),tag(\"keptn_selfmon_namespace:keptn-hardening\")",
+  "target": 95,
+  "warning": 97.5,
+  "timeframe": "-1d"
+}

--- a/assets/monaco/slo/slo.yaml
+++ b/assets/monaco/slo/slo.yaml
@@ -1,0 +1,14 @@
+config:
+  - service_availability: "service_availability.json"
+  - mongodb_datastore_performance: "performance.json"
+
+service_availability:
+  - name: "Keptn Service Availability"
+  - project: "{{ .Env.KEPTN_PROJECT }}"
+  - stage: "{{ .Env.KEPTN_STAGE }}"
+
+mongodb_datastore_performance:
+  - name: "Performance"
+  - project: "{{ .Env.KEPTN_PROJECT }}"
+  - stage: "{{ .Env.KEPTN_STAGE }}"
+  - service: "mongodb-datastore"

--- a/assets/monaco/slo/slo.yaml
+++ b/assets/monaco/slo/slo.yaml
@@ -12,3 +12,4 @@ mongodb_datastore_performance:
   - project: "{{ .Env.KEPTN_PROJECT }}"
   - stage: "{{ .Env.KEPTN_STAGE }}"
   - service: "mongodb-datastore"
+  - metricId: "/{{ .Env.KEPTN_PROJECT }}/calculated-metrics-service/calculated-metrics-fastrequests.id"

--- a/deploy_dynatrace.sh
+++ b/deploy_dynatrace.sh
@@ -105,6 +105,7 @@ else
   helm install dynatrace-sli-service https://github.com/keptn-contrib/dynatrace-sli-service/releases/download/${DYNATRACE_SLI_SERVICE_VERSION}/dynatrace-sli-service-${DYNATRACE_SLI_SERVICE_VERSION}.tgz -n keptn
 fi
 
+
 wait_for_deployment_in_namespace "dynatrace-service" "keptn"
 wait_for_deployment_in_namespace "dynatrace-sli-service" "keptn"
 

--- a/monaco.triggered.json
+++ b/monaco.triggered.json
@@ -1,0 +1,11 @@
+{
+  "type": "sh.keptn.event.monaco.triggered",
+  "specversion": "1.0",
+  "source": "test-events",
+  "contenttype": "application/json",
+  "data": {
+    "project": "keptn",
+    "stage": "hardening",
+    "service": "keptn"
+  }
+}

--- a/setup_monaco.sh
+++ b/setup_monaco.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source ${BASE_PATH}/utils.sh
+
+echo "deploying monaco-service"
+kubectl apply -f https://raw.githubusercontent.com/keptn-sandbox/monaco-service/${MONACO_SERVICE_VERSION}/deploy/service.yaml -n keptn
+
+wait_for_deployment_in_namespace "monaco-service" "keptn"
+
+# Management Zone
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/management-zone/zone.yaml --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/management-zone/zone.yaml --all-stages
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/management-zone/zone.json --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/management-zone/zone.json --all-stages
+
+# Tagging rules
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/auto-tag/tagging.yaml --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/auto-tag/tagging.yaml --all-stages
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/auto-tag/keptn_selfmon_namespace.json --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/auto-tag/keptn_selfmon_namespace.json --all-stages
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/auto-tag/keptn_selfmon_service.json --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/auto-tag/keptn_selfmon_service.json --all-stages
+
+# Service Naming
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/conditional-naming/conditional-naming-service.yaml --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/conditional-naming-service/conditional-naming-service.yaml --all-stages
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/conditional-naming/keptn_service.json --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/conditional-naming-service/keptn_service.json --all-stages
+
+# Custom Metrics
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/calculated-metrics-service/calculated-metrics-service.yaml --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/calculated-metrics-service/calculated-metrics-service.yaml --all-stages
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/calculated-metrics-service/fast_requests.json --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/calculated-metrics-service/fast_requests.json --all-stages
+
+# SLOs
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/slo/slo.yaml --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/slo/slo.yaml --all-stages
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/slo/performance.json --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/slo/performance.json --all-stages
+keptn add-resource --project=${KEPTN_SELF_MONITORING_PROJECT} --service=keptn --resource=${BASE_PATH}/assets/monaco/slo/service_availability.json --resourceUri=dynatrace/projects/${KEPTN_SELF_MONITORING_PROJECT}/slo/service_availability.json --all-stages


### PR DESCRIPTION
This PR enhances the action by deploying the [keptn-sandbox/monaco-service](https://github.com/keptn-sandbox/monaco-service), and setting up the DT environment using monaco files.
These include:

- Naming rules for better identification of Keptn core services within DT
- Custom metrics to define SLOs
- Management Zone for Keptn